### PR TITLE
fix amount calculation

### DIFF
--- a/src/processors/tokenTransferProcessor.ts
+++ b/src/processors/tokenTransferProcessor.ts
@@ -4,6 +4,7 @@ import {
   getOrCreateAssociatedTokenAccount,
 } from "@solana/spl-token";
 import { Connection, Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import { getBN } from "@streamflow/stream";
 import BN from "bn.js";
 import { IRecipientInfo } from "../utils/recipientStream";
 
@@ -17,10 +18,7 @@ export const processTokenTransfer = async (
   const recentBlockInfo = await connection.getLatestBlockhash();
   const recipientAta = await getOrCreateAssociatedTokenAccount(connection, sender, mint, recipientInfo.address);
   const senderAta = await getAssociatedTokenAddress(mint, sender.publicKey);
-  const amount = new BN((recipientInfo.amount * 10e9).toFixed(0))
-    .mul(new BN(10).pow(new BN(decimals)))
-    .div(new BN(10e9))
-    .toString();
+  const amount = getBN(recipientInfo.amount, decimals).toString();
 
   const ix = createTransferCheckedInstruction(
     senderAta,

--- a/src/processors/vestingContractProcessor.ts
+++ b/src/processors/vestingContractProcessor.ts
@@ -1,5 +1,5 @@
 import { Connection, Keypair, PublicKey, SYSVAR_RENT_PUBKEY, SystemProgram, Transaction } from "@solana/web3.js";
-import { StreamflowSolana } from "@streamflow/stream";
+import { StreamflowSolana, getBN } from "@streamflow/stream";
 import { IRecipientInfo } from "../utils/recipientStream";
 import { ICluster } from "@streamflow/stream/dist/common/types";
 import {
@@ -37,9 +37,7 @@ export const processVestingContract = async (
     mint,
     STREAMFLOW_TREASURY_PUBLIC_KEY
   );
-  const amount = new BN((recipientInfo.amount * 10e9).toFixed(0))
-    .mul(new BN(10).pow(new BN(decimals)))
-    .div(new BN(10e9));
+  const amount = getBN(recipientInfo.amount, decimals);
   const period = streamParameters.duration / streamParameters.unlockCount;
   const amountWithoutCliff = amount.mul(new BN(10000 - 100 * streamParameters.cliffPercentage)).div(new BN(10000));
   const amountPerPeriod = amountWithoutCliff.div(new BN(streamParameters.unlockCount));


### PR DESCRIPTION
- drop decimal points from amount after multiplying 10**9 to fix BN conversion

Previously this csv would fail to be processed, now it works:
```
Amount,Wallet Address,Title,Email
160000000.5,CTKGuKct3cajH2dqND35Qy3Zwqtwy3wmyUxYK1xbE5ti,Seed Round VC #1,""
```
