### PR TITLE
custom rebroadcasting logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ import {
 import { RecipientProgress } from "./utils/progress";
 import { IRecipientInfo, createRecipientStream } from "./utils/recipientStream";
 import { getTokenDecimals, getTokenMetadataMap, getUserTokens, prepareUserChoices } from "./utils/tokens";
+import { toStringifyArray } from "./utils/privateKey";
+
 
 (async () => {
   const cli = new CLIService<ICLIOptions>(cliOptions);
@@ -31,7 +33,9 @@ import { getTokenDecimals, getTokenMetadataMap, getUserTokens, prepareUserChoice
   console.log("Reading private key.");
   const keyPath = cli.getOptions().key;
   const keyPathFormatted = path.isAbsolute(keyPath) ? keyPath : path.join(process.cwd(), keyPath);
-  const privateKey = JSON.parse(fs.readFileSync(keyPathFormatted).toString());
+  let privateKey = JSON.parse(fs.readFileSync(keyPathFormatted).toString());
+  privateKey = toStringifyArray(privateKey);
+
   const keypair = Keypair.fromSeed(Buffer.from(privateKey).subarray(0, 32));
   const wallet = new Wallet(keypair);
   const sender = wallet.publicKey;

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,9 +33,10 @@ import { toStringifyArray } from "./utils/privateKey";
   console.log("Reading private key.");
   const keyPath = cli.getOptions().key;
   const keyPathFormatted = path.isAbsolute(keyPath) ? keyPath : path.join(process.cwd(), keyPath);
-  let privateKey = JSON.parse(fs.readFileSync(keyPathFormatted).toString());
+  let privateKey = fs.readFileSync(keyPathFormatted).toString();
   privateKey = toStringifyArray(privateKey);
 
+  privateKey = JSON.parse(privateKey)
   const keypair = Keypair.fromSeed(Buffer.from(privateKey).subarray(0, 32));
   const wallet = new Wallet(keypair);
   const sender = wallet.publicKey;

--- a/src/processors/vestingContractProcessor.ts
+++ b/src/processors/vestingContractProcessor.ts
@@ -31,7 +31,6 @@ export const processVestingContract = async (
   if (!programId) {
     programId = PROGRAM_ID[useDevnet ? ICluster.Devnet : ICluster.Mainnet];
   }
-  console.log("###",sender.publicKey.toString());
   const pid = new PublicKey(programId);
   const metadata = Keypair.generate();
   const [escrowTokens] = PublicKey.findProgramAddressSync([Buffer.from("strm"), metadata.publicKey.toBuffer()], pid);
@@ -124,7 +123,6 @@ export const processVestingContract = async (
   const rawTransaction = tx.serialize();
   try {
     while (blockheight < recentBlockInfo.lastValidBlockHeight) {
-      console.log("#### Send Raw Transaction")
       await connection.sendRawTransaction(rawTransaction, { maxRetries: 0, minContextSlot: context.slot, preflightCommitment: commitment, skipPreflight: true });
       await sleep(500);
       const value = await confirmAndEnsureTransaction(connection, signature);
@@ -138,7 +136,6 @@ export const processVestingContract = async (
     await sleep(3000);
   }
 
-  console.log("#### Confirm Transaction")
   while (blockheight < recentBlockInfo.lastValidBlockHeight + 50) {
     blockheight = await connection.getBlockHeight(commitment);
     const value = await confirmAndEnsureTransaction(connection, signature);

--- a/src/processors/vestingContractProcessor.ts
+++ b/src/processors/vestingContractProcessor.ts
@@ -91,7 +91,7 @@ export const processVestingContract = async (
     },
   );
 
-  const commitment = "confirmed";
+  const commitment = "finalized";
   const { context, value: recentBlockInfo } = await connection.getLatestBlockhashAndContext({ commitment });
 
   const ixs: TransactionInstruction[] = [ComputeBudgetProgram.setComputeUnitLimit({ units: 220_000 })];

--- a/src/processors/vestingContractProcessor.ts
+++ b/src/processors/vestingContractProcessor.ts
@@ -110,10 +110,9 @@ export const processVestingContract = async (
     const res = await connection.simulateTransaction(tx, { commitment });
     if (res.value.err) {
       const errMessage = res.value.err.toString();
-      if (errMessage.includes("BlockhashNotFound") && i < 2) {
-        continue
+      if (!errMessage.includes("BlockhashNotFound") || i === 2) {
+        throw new Error(errMessage);
       }
-      throw new Error(errMessage);
     }
     break;
   }

--- a/src/utils/privateKey.ts
+++ b/src/utils/privateKey.ts
@@ -1,0 +1,9 @@
+import bs58 from "bs58";
+
+export function toStringifyArray(base58PrivateKey: string): string {
+    // It's already stringified array
+    if(base58PrivateKey.length >= 64)
+        return base58PrivateKey;
+
+    return JSON.stringify(Array.from(bs58.decode(base58PrivateKey)))
+}

--- a/src/utils/privateKey.ts
+++ b/src/utils/privateKey.ts
@@ -1,9 +1,9 @@
 import bs58 from "bs58";
 
 export function toStringifyArray(base58PrivateKey: string): string {
-    // It's already stringified array
-    if(base58PrivateKey.length >= 64)
-        return base58PrivateKey;
+  const stringifiedArrayRegex = new RegExp("[d+(,d+)*]");
+  // It's already stringified array
+  if (stringifiedArrayRegex.test(base58PrivateKey)) return base58PrivateKey;
 
-    return JSON.stringify(Array.from(bs58.decode(base58PrivateKey)))
+  return JSON.stringify(Array.from(bs58.decode(JSON.parse(base58PrivateKey))));
 }


### PR DESCRIPTION
- don't rely on confirmTransaction by web3js client, confirm txs manually
- rebroadcast txs with `sendRawTransaction`
- use simulation separately
- use `confirmed` commitment everywhere
- add additional error catches to make it safer from duplicate txs