### PR TITLE
STREAM-1457: brute-force approach, retry until we land or die

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ The script will enquire you about all vesting parameters in interactive prompt. 
 
 NOTE: to completely disable vesting options pass `--vesting-options=` (include equal sign to specify that the passed value is an empty string)
 
+#### Brute-force approach
+
+As Solana is heavily congested at the time of writing this, we've implemented a "brute-force" approach for Solana tx landing:
+
+- script retries transactions indefinitely until they either land or error out (blockhash expiring does not count);
+- with every tx send loop we check whether a Contract for mint/recipient combination already exist - if the do, we'll skip this recipient and write the existing Contract ID to success csv file;
+- custom rebroadcasting is implemented:
+  - we send tx in a loop and check whether it has landed with some backoff;
+  - we check for tx being landed until Blockhash of the tx expires + we add 15 blocks for checks to make sure;
+  - tx rebroadcasting by itself is throttled - as most of RPC pools have pretty strict limitations - up to 2 tx broadcasts in a second;
+- as TXs are basically racing with each other we limited the concurrency of Vesting Contracts creation - up to 20 Contracts will be processed at a time;
+
 ### Priority Fees
 
 Solana network may be congested, so using just base fee may not be enough to process transaction at times. In this case we recommend to use Priority Fees https://solana.com/developers/guides/advanced/how-to-use-priority-fees.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@solana/spl-token-registry": "0.2.7",
         "@solana/web3.js": "^1.90.0",
         "@streamflow/common": "^6.0.3",
-        "@streamflow/stream": "^6.1.1",
+        "@streamflow/stream": "^6.2.1",
         "ansi-colors": "^4.1.3",
         "bignumber.js": "^9.1.2",
         "bs58": "^5.0.0",
@@ -26,6 +26,7 @@
         "figlet": "^1.7.0",
         "map-stream": "^0.0.7",
         "node-fetch": "^3.3.2",
+        "p-queue": "^6.6.2",
         "progress": "^2.0.3",
         "stream-throttle": "^0.1.3",
         "throttled-queue": "^2.1.4"
@@ -3560,9 +3561,9 @@
       "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
     },
     "node_modules/@streamflow/common": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@streamflow/common/-/common-6.1.1.tgz",
-      "integrity": "sha512-vyMLauiuxCpRYDkg4VpYk+8OukrMaXN0/U8+kPjqxOO1QD2BUVEJhq6fzHYxQudYBYYBg7mLysCZOjaed6LfpQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@streamflow/common/-/common-6.2.1.tgz",
+      "integrity": "sha512-Z97id2fD1FBQe+ubp7akn0ixtzJV7J9GY9U+IYwjD1JRW519pWUaVsZFMxT4m2NCzJ+81WvUl91cgToImsH7kQ==",
       "dependencies": {
         "@coral-xyz/borsh": "^0.29.0",
         "@solana/buffer-layout": "4.0.1 ",
@@ -3754,9 +3755,9 @@
       "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
     },
     "node_modules/@streamflow/stream": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@streamflow/stream/-/stream-6.1.1.tgz",
-      "integrity": "sha512-XKN9D1wYpdepsXIiSt61bw1/nWLNX//Jx3O7REVQg8KfAZqXg1AUINRLoVCdE9IbsAmv2inmIXEgx8JocxNXJQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@streamflow/stream/-/stream-6.2.1.tgz",
+      "integrity": "sha512-DDITKzrUiSYKXXwbhe7FGnhwoeb8Pd1IT2VEnAneuaKQ1rnYgYPQzW2+0YOBxDSNC3oByd+LzLinF/xUENeeqQ==",
       "dependencies": {
         "@coral-xyz/borsh": "^0.29.0",
         "@manahippo/aptos-wallet-adapter": "1.0.6",
@@ -3765,7 +3766,7 @@
         "@solana/spl-token": "0.3.6",
         "@solana/wallet-adapter-base": "0.9.19",
         "@solana/web3.js": "1.70.1",
-        "@streamflow/common": "6.1.1",
+        "@streamflow/common": "6.2.1",
         "@suiet/wallet-kit": "0.2.22",
         "aptos": "1.4.0",
         "bn.js": "5.2.1",
@@ -6416,18 +6417,12 @@
         "wrappy": "1"
       }
     },
-    "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/p-locate": {
@@ -6442,6 +6437,57 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pako": {
@@ -7551,17 +7597,6 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@solana/spl-token-registry": "0.2.7",
     "@solana/web3.js": "^1.90.0",
     "@streamflow/common": "^6.0.3",
-    "@streamflow/stream": "^6.1.1",
+    "@streamflow/stream": "^6.2.1",
     "ansi-colors": "^4.1.3",
     "bignumber.js": "^9.1.2",
     "bs58": "^5.0.0",
@@ -31,6 +31,7 @@
     "map-stream": "^0.0.7",
     "node-fetch": "^3.3.2",
     "progress": "^2.0.3",
+    "p-queue": "^6.6.2",
     "stream-throttle": "^0.1.3",
     "throttled-queue": "^2.1.4"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,11 +164,11 @@ const PROCESS_QUEUE = new PQueue({ concurrency: 20 });
   }));
 
   recipientStream.on("close", async () => {
-    while (processingStarted && progress.getTokens().active > 0) {
+    while (processingStarted && progress.getProgressTokens().active > 0) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
     progress.end();
-    const tokens = progress.getTokens();
+    const tokens = progress.getProgressTokens();
     fs.writeFileSync(recipientsPath, [[...columns, fileHash].join(","), ...csvContent].join("\n"));
     console.log("\nCSV file has been processed!");
     if (tokens.success) console.log(chalk.green(`${tokens.success} Transfers have been successful!`));

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { createHash } from "crypto";
 import { prompt } from "enquirer";
 import fs from "fs";
 import path from "path";
+import PQueue from "p-queue";
 import { Transform } from "stream";
 
 import { CLIService } from "./CLIService";
@@ -24,6 +25,12 @@ import { getTokenDecimals, getTokenMetadataMap, getUserTokens, prepareUserChoice
 import { toStringifyArray } from "./utils/privateKey";
 
 
+// To ensure that no more than 1 progress ticks happen at a time
+const TICK_QUEUE = new PQueue({ concurrency: 1 });
+// Up to 20 concurrent tasks on processing
+const PROCESS_QUEUE = new PQueue({ concurrency: 20 });
+
+
 (async () => {
   const cli = new CLIService<ICLIOptions>(cliOptions);
   await cli.init();
@@ -34,7 +41,7 @@ import { toStringifyArray } from "./utils/privateKey";
   let privateKey = fs.readFileSync(keyPathFormatted).toString();
   privateKey = toStringifyArray(privateKey);
 
-  privateKey = JSON.parse(privateKey)
+  privateKey = JSON.parse(privateKey);
   const keypair = Keypair.fromSeed(Buffer.from(privateKey).subarray(0, 32));
   const wallet = new Wallet(keypair);
   const sender = wallet.publicKey;
@@ -68,17 +75,23 @@ import { toStringifyArray } from "./utils/privateKey";
   const columns = recipientsFile.trim().split("\n")[0].split(",");
   const csvContent = recipientsFile.trim().split("\n").slice(1);
   const lastColumn = columns.at(-1);
-  const isValidHash = /^[A-Fa-f0-9]{64}$/.test(lastColumn || '');
+  const isValidHash = /^[A-Fa-f0-9]{64}$/.test(lastColumn || "");
   const fileHash = createHash("sha256").update(csvContent.join("\n")).digest("hex");
 
   if (isValidHash) {
     let msg: string;
     if (lastColumn === fileHash) {
-      msg = 'This file has already been processed, are you sure you want to proceed?'
+      msg = "This file has already been processed, are you sure you want to proceed?";
     } else {
-      msg = 'It seems that this file has already been processed, but was modified afterwards. Are you sure you want to proceed?'
+      msg = "It seems that this file has already been processed, but was modified afterwards. Are you sure you want to proceed?";
     }
-    const res = await prompt<{ proceed: boolean }>({ name: 'proceed', type: 'toggle', enabled: 'Yes', disabled: 'No', message: msg })
+    const res = await prompt<{ proceed: boolean }>({
+      name: "proceed",
+      type: "toggle",
+      enabled: "Yes",
+      disabled: "No",
+      message: msg,
+    });
     if (!res.proceed) {
       return;
     }
@@ -94,12 +107,12 @@ import { toStringifyArray } from "./utils/privateKey";
   const computePrice = priorityFee;
 
   const res = await prompt<{ proceed: boolean }>({
-    name: 'proceed',
-    type: 'toggle',
-    enabled: 'Yes',
-    disabled: 'No',
-    message: 'Are all these parameters correct? Pressing `Yes` will start the procedure.'
-  })
+    name: "proceed",
+    type: "toggle",
+    enabled: "Yes",
+    disabled: "No",
+    message: "Are all these parameters correct? Pressing `Yes` will start the procedure.",
+  });
   if (!res.proceed) {
     return;
   }
@@ -107,36 +120,30 @@ import { toStringifyArray } from "./utils/privateKey";
   const progress = new RecipientProgress();
 
   const recipientStream: Transform = createRecipientStream(recipientsPath, rate);
-  let successCounter = 0;
-  const { stream: successStream, name: successName } = createSuccessPipe(!!isVestingContract);
+  const { stream: successStream, name: successName } = createSuccessPipe(isVestingContract);
   successStream.pipe(createFileStream(successName));
-  let invalidCounter = 0;
   const { stream: invalidStream, name: invalidName } = createInvalidPipe();
   invalidStream.pipe(createFileStream(invalidName));
-  let errorCounter = 0;
   const { stream: errorStream, name: errorName } = createErrorPipe();
   errorStream.pipe(createFileStream(errorName));
 
   const startTime = process.hrtime();
-  let activeProcessing = 0;
   let processingStarted = false;
 
-  recipientStream.on("data", async (row: IRecipientInfo) => {
-    activeProcessing++;
+  recipientStream.on("data", async (row: IRecipientInfo) => PROCESS_QUEUE.add(async () => {
     processingStarted = true;
     if (!row.isValid) {
       invalidStream.write(row.rawData.split(","));
-      progress.invalid();
-      invalidCounter++;
-      activeProcessing--;
+      await TICK_QUEUE.add(() => progress.tick("invalid"));
       return;
     }
+    await TICK_QUEUE.add(() => progress.tick("active", 0, 1));
 
     try {
       if (isVestingContract) {
         const { txId, contractId } = await processVestingContract(
           connection,
-          !!useDevnet,
+          useDevnet,
           programId,
           keypair,
           row,
@@ -150,32 +157,31 @@ import { toStringifyArray } from "./utils/privateKey";
         const { txId } = await processTokenTransfer(connection, keypair, row, mint, decimals, computePrice);
         successStream.write([row.amount, row.address.toBase58(), row.name, row.email, txId]);
       }
-      progress.success();
-      successCounter++;
+      await TICK_QUEUE.add(() => progress.tick("success"));
     } catch (e) {
-      progress.retry();
+      await TICK_QUEUE.add(() => progress.tick("retries"));
       errorStream.write(row.rawData.split(","));
       console.info(`\n${row.address}: ${e}`);
-      errorCounter++;
     }
-    activeProcessing--;
-  });
+    await TICK_QUEUE.add(() => progress.tick("active", 0, -1));
+  }));
 
   recipientStream.on("close", async () => {
-    while (processingStarted && activeProcessing > 0) {
+    while (processingStarted && progress.getTokens().active > 0) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
     progress.end();
+    const tokens = progress.getTokens();
     fs.writeFileSync(recipientsPath, [[...columns, fileHash].join(","), ...csvContent].join("\n"));
     console.log("\nCSV file has been processed!");
-    if (successCounter) console.log(chalk.green(`${successCounter} Transfers have been successful!`));
-    if (errorCounter)
+    if (tokens.success) console.log(chalk.green(`${tokens.success} Transfers have been successful!`));
+    if (tokens.retries)
       console.log(
         chalk.yellow(
-          `${errorCounter} Transfers have failed, you can retry transfers by reusing ${errorName} output file!`,
+          `${tokens["retries"]} Transfers have failed, you can retry transfers by reusing ${errorName} output file!`,
         ),
       );
-    if (invalidCounter) console.log(chalk.red(`There were ${invalidCounter} invalid rows in the provided file!`));
+    if (tokens.invalid) console.log(chalk.red(`There were ${tokens.invalid} invalid rows in the provided file!`));
 
     const endTime = process.hrtime(startTime);
     const elapsedSeconds = (endTime[0] + endTime[1] / 1e9).toFixed(3);

--- a/src/processors/vestingContractProcessor.ts
+++ b/src/processors/vestingContractProcessor.ts
@@ -3,23 +3,33 @@ import {
   TOKEN_PROGRAM_ID,
   getAssociatedTokenAddress,
 } from "@solana/spl-token";
-import { ComputeBudgetProgram, Connection, Keypair, PublicKey, SendTransactionError, SYSVAR_RENT_PUBKEY, SystemProgram, TransactionInstruction, TransactionMessage, VersionedTransaction } from "@solana/web3.js";
-import { StreamflowSolana, getBN } from "@streamflow/stream";
-import { decodeStream, constants } from "@streamflow/stream/solana";
-import { ICluster, sleep } from "@streamflow/common";
-import { confirmAndEnsureTransaction, TransactionFailedError } from "@streamflow/common/solana";
+import {
+  ComputeBudgetProgram,
+  Connection,
+  Keypair,
+  PublicKey,
+  SendTransactionError,
+  SYSVAR_RENT_PUBKEY,
+  SystemProgram,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { createStreamInstruction, constants } from "@streamflow/stream/solana";
+import { ICluster, sleep, getBN } from "@streamflow/common";
+import { confirmAndEnsureTransaction, simulateTransaction, TransactionFailedError } from "@streamflow/common/solana";
 import BN from "bn.js";
 import bs58 from "bs58";
-import throttledQueue from 'throttled-queue';
+import PQueue from "p-queue";
 
 import { ICLIStreamParameters } from "../CLIService/streamParameters";
 import { IRecipientInfo } from "../utils/recipientStream";
+import { buildStreamTransaction, fetchExistingStream } from "../utils/vesting";
 
-const MINT_OFFSET = 177;
-const SEND_THROTTLE = throttledQueue(2, 1000); // 2 sends per second
-const { PROGRAM_ID, STREAMFLOW_TREASURY_PUBLIC_KEY, FEE_ORACLE_PUBLIC_KEY, WITHDRAWOR_PUBLIC_KEY } =
-  StreamflowSolana.constants;
-const { createStreamInstruction } = StreamflowSolana;
+const DEFAULT_CU = 220_000;
+const SIMULATION_CU = 500_000;
+const COMPUTE_ERROR_MARGIN = 1_000;
+// Up to 2 TX sends at a time, up to 2 per 1 second
+const SEND_QUEUE = new PQueue({ concurrency: 2, intervalCap: 2, interval: 1000 });
+const { PROGRAM_ID, STREAMFLOW_TREASURY_PUBLIC_KEY, FEE_ORACLE_PUBLIC_KEY, WITHDRAWOR_PUBLIC_KEY } = constants;
 
 export const processVestingContract = async (
   connection: Connection,
@@ -36,26 +46,6 @@ export const processVestingContract = async (
     programId = PROGRAM_ID[useDevnet ? ICluster.Devnet : ICluster.Mainnet];
   }
   const pid = new PublicKey(programId);
-  const streams = await connection.getProgramAccounts(pid, {
-    filters: [
-      {
-        memcmp: {
-          offset: MINT_OFFSET,
-          bytes: mint.toBase58(),
-        },
-      },
-      {
-        memcmp: {
-          offset: constants.STREAM_STRUCT_OFFSET_RECIPIENT,
-          bytes: recipientInfo.address.toBase58(),
-        },
-      },
-    ],
-  })
-  if (streams.length > 0) {
-    console.log(`Recipient ${recipientInfo.address.toBase58()} already has a stream for this mint, will skip`)
-    return { txId: "", contractId: streams[0].pubkey.toBase58() }
-  }
   const metadata = Keypair.generate();
   const [escrowTokens] = PublicKey.findProgramAddressSync([Buffer.from("strm"), metadata.publicKey.toBuffer()], pid);
 
@@ -114,79 +104,77 @@ export const processVestingContract = async (
     },
   );
 
-  const commitment = "confirmed";
-  const { context, value: recentBlockInfo } = await connection.getLatestBlockhashAndContext({ commitment });
+  const commitment = "finalized";
 
-  const ixs: TransactionInstruction[] = [ComputeBudgetProgram.setComputeUnitLimit({ units: 220_000 })];
+  const ixs: TransactionInstruction[] = [ComputeBudgetProgram.setComputeUnitLimit({ units: SIMULATION_CU })];
   if (computePrice) {
     ixs.push(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: computePrice }));
   }
   ixs.push(ix);
-  const messageV0 = new TransactionMessage({
-    payerKey: sender.publicKey,
-    recentBlockhash: recentBlockInfo.blockhash,
-    instructions: ixs,
-  }).compileToV0Message();
-  const tx = new VersionedTransaction(messageV0);
-  tx.sign([sender, metadata]);
 
-  for (let i = 0; i < 3; i++) {
-    const res = await connection.simulateTransaction(tx, { commitment });
-    if (res.value.err) {
-      const errMessage = res.value.err.toString();
-      if (!errMessage.includes("BlockhashNotFound") || i === 2) {
-        throw new Error(errMessage);
-      }
+  while (true) {
+    const contractId = await fetchExistingStream(connection, pid, mint, recipientInfo.address);
+    if (contractId) {
+      console.log(`Recipient ${recipientInfo.address.toBase58()} already has a stream for this mint, will skip`);
+      return { txId: "", contractId: contractId };
     }
-    break;
-  }
 
-  let signature = bs58.encode(tx.signatures[0]);
-  let blockheight = await connection.getBlockHeight(commitment);
-  const rawTransaction = tx.serialize();
-  let transactionSent = false;
-  while (blockheight < recentBlockInfo.lastValidBlockHeight + 15) {
-    try {
-      if (blockheight < recentBlockInfo.lastValidBlockHeight || !transactionSent) {
-        await SEND_THROTTLE(async () => {
-          await connection.sendRawTransaction(rawTransaction, {
-            maxRetries: 0,
-            minContextSlot: context.slot,
-            preflightCommitment: commitment,
-            skipPreflight: true,
-          })
-        });
-        transactionSent = true;
-      }
-    } catch (e) {
-      if (
-        transactionSent ||
-        (e instanceof SendTransactionError && e.message.includes("Minimum context slot has not been reached"))
-      ) {
-        await sleep(500);
-        continue;
-      }
-      throw e;
+    const { context, value: recentBlockInfo } = await connection.getLatestBlockhashAndContext({ commitment });
+    let tx = buildStreamTransaction(ixs, recentBlockInfo.blockhash, sender, metadata);
+    const res = await simulateTransaction(connection, tx);
+    let newCu = DEFAULT_CU;
+    if (res.value.unitsConsumed) {
+      newCu = Math.floor(res.value.unitsConsumed * (1 + COMPUTE_ERROR_MARGIN / 10_000));
     }
-    await sleep(500);
-    try {
-      const value = await confirmAndEnsureTransaction(connection, signature);
-      if (value) {
-        return { txId: signature, contractId: metadata.publicKey.toBase58() };
+    ixs[0] = ComputeBudgetProgram.setComputeUnitLimit({ units: newCu });
+    tx = buildStreamTransaction(ixs, recentBlockInfo.blockhash, sender, metadata);
 
-      }
-    } catch (e) {
-      if (e instanceof TransactionFailedError) {
+    let signature = bs58.encode(tx.signatures[0]);
+    let blockheight = await connection.getBlockHeight(commitment);
+    const rawTransaction = tx.serialize();
+    let transactionSent = false;
+    while (blockheight < recentBlockInfo.lastValidBlockHeight + 15) {
+      try {
+        if (blockheight < recentBlockInfo.lastValidBlockHeight || !transactionSent) {
+          await SEND_QUEUE.add(async () => {
+            await connection.sendRawTransaction(rawTransaction, {
+              maxRetries: 0,
+              minContextSlot: context.slot,
+              preflightCommitment: commitment,
+              skipPreflight: true,
+            });
+          });
+          transactionSent = true;
+        }
+      } catch (e) {
+        if (
+          transactionSent ||
+          (e instanceof SendTransactionError && e.message.includes("Minimum context slot has not been reached"))
+        ) {
+          await sleep(500);
+          continue;
+        }
         throw e;
       }
       await sleep(500);
+      try {
+        const value = await confirmAndEnsureTransaction(connection, signature);
+        if (value) {
+          return { txId: signature, contractId: metadata.publicKey.toBase58() };
+        }
+      } catch (e) {
+        if (e instanceof TransactionFailedError) {
+          throw e;
+        }
+        await sleep(500);
+      }
+      try {
+        blockheight = await connection.getBlockHeight(commitment);
+      } catch (_e) {
+        await sleep(500);
+      }
     }
-    try {
-      blockheight = await connection.getBlockHeight(commitment);
-    } catch (_e) {
-      await sleep(500);
-    }
+    console.warn(`${recipientInfo.address}: transaction ${signature} expired. Will retry in 5...`);
+    await sleep(5000);
   }
-
-  throw new Error(`${recipientInfo.address}: transaction ${signature} expired.`);
 };

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -4,7 +4,7 @@ export class RecipientProgress {
   private progress: ProgressBar;
 
   constructor() {
-    this.progress = new ProgressBar("Processed: :current / Success :success / Errors: :retries / Invalid :invalid  ", {
+    this.progress = new ProgressBar("Processed: :current / Success :success / Errors: :retries / Invalid :invalid / Active :active  ", {
       total: 1000000,
     });
 
@@ -12,40 +12,23 @@ export class RecipientProgress {
       success: 0,
       invalid: 0,
       retries: 0,
+      active: 0,
     });
   }
 
-  public success() {
-    const success = (this.progress as any)?.tokens?.success || 0;
-    const invalid = (this.progress as any)?.tokens?.invalid || 0;
-    const retries = (this.progress as any)?.tokens?.retries || 0;
-    this.progress.tick({
-      success: success + 1,
-      invalid,
-      retries,
-    });
+  public tick(token: "success" | "invalid" | "retries" | "active", tickCounter: number = 1, tokenCounter: number = 1) {
+    const tokens = this.getTokens();
+    tokens[token] += tokenCounter;
+    this.progress.tick(tickCounter, tokens);
   }
 
-  public invalid() {
-    const success = (this.progress as any)?.tokens?.success || 0;
-    const invalid = (this.progress as any)?.tokens?.invalid || 0;
-    const retries = (this.progress as any)?.tokens?.retries || 0;
-    this.progress.tick({
-      success,
-      invalid: invalid + 1,
-      retries,
-    });
-  }
-
-  public retry() {
-    const success = (this.progress as any)?.tokens?.success || 0;
-    const invalid = (this.progress as any)?.tokens?.invalid || 0;
-    const retries = (this.progress as any)?.tokens?.retries || 0;
-    this.progress.tick({
-      success,
-      invalid,
-      retries: retries + 1,
-    });
+  public getTokens(): { success: number; invalid: number; retries: number; active: number } {
+    return {
+      success: (this.progress as any)?.tokens?.success || 0,
+      invalid: (this.progress as any)?.tokens?.invalid || 0,
+      retries: (this.progress as any)?.tokens?.retries || 0,
+      active: (this.progress as any)?.tokens?.active || 0,
+    };
   }
 
   public end() {

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -22,13 +22,13 @@ export class RecipientProgress {
 
   public async tick(token: "success" | "invalid" | "retries" | "active", tickCounter: number = 1, tokenCounter: number = 1) {
     await TICK_QUEUE.add(() => {
-      const tokens = this.getTokens();
+      const tokens = this.getProgressTokens();
       tokens[token] += tokenCounter;
       this.progress.tick(tickCounter, tokens);
     })
   }
 
-  public getTokens(): { success: number; invalid: number; retries: number; active: number } {
+  public getProgressTokens(): { success: number; invalid: number; retries: number; active: number } {
     return {
       success: (this.progress as any)?.tokens?.success || 0,
       invalid: (this.progress as any)?.tokens?.invalid || 0,

--- a/src/utils/vesting.ts
+++ b/src/utils/vesting.ts
@@ -1,0 +1,46 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { constants } from "@streamflow/stream/solana";
+
+const MINT_OFFSET = 177;
+
+export async function fetchExistingStream(connection: Connection, programId: PublicKey, mint: PublicKey, recipient: PublicKey): Promise<string | null> {
+  const streams = await connection.getProgramAccounts(programId, {
+    filters: [
+      {
+        memcmp: {
+          offset: MINT_OFFSET,
+          bytes: mint.toBase58(),
+        },
+      },
+      {
+        memcmp: {
+          offset: constants.STREAM_STRUCT_OFFSET_RECIPIENT,
+          bytes: recipient.toBase58(),
+        },
+      },
+    ],
+  });
+  if (streams.length > 0) {
+    return streams[0].pubkey.toBase58();
+  }
+  return null;
+}
+
+
+export function buildStreamTransaction(ixs: TransactionInstruction[], blockhash: string, sender: Keypair, metadata: Keypair): VersionedTransaction {
+  const messageV0 = new TransactionMessage({
+    payerKey: sender.publicKey,
+    recentBlockhash: blockhash,
+    instructions: ixs,
+  }).compileToV0Message();
+  const tx = new VersionedTransaction(messageV0);
+  tx.sign([sender, metadata]);
+  return tx;
+}


### PR DESCRIPTION
- for now merging to `Wormhole` branch as we'll need to add additional CLI parameters to properly merge this approach into main

Copying description from README:

#### Brute-force approach

As Solana is heavily congested at the time of writing this, we've implemented a "brute-force" approach for Solana tx landing:

- script retries transactions indefinitely until they either land or error out (blockhash expiring does not count);
- with every tx send loop we check whether a Contract for mint/recipient combination already exist - if the do, we'll skip this recipient and write the existing Contract ID to success csv file;
- custom rebroadcasting is implemented:
  - we send tx in a loop and check whether it has landed with some backoff;
  - we check for tx being landed until Blockhash of the tx expires + we add 15 blocks for checks to make sure;
  - tx rebroadcasting by itself is throttled - as most of RPC pools have pretty strict limitations - up to 2 tx broadcasts in a second;
- as TXs are basically racing with each other we limited the concurrency of Vesting Contracts creation - up to 20 Contracts will be processed at a time;